### PR TITLE
Remove TR non compatible message when syncing,

### DIFF
--- a/WiiTUIO/KeymapConfig/KeymapDatabase.cs
+++ b/WiiTUIO/KeymapConfig/KeymapDatabase.cs
@@ -113,7 +113,7 @@ namespace WiiTUIO
             allOutputs.Add(new KeymapOutput(KeymapOutputType.MOUSE, "Mouse Left", "mouseleft"));
             allOutputs.Add(new KeymapOutput(KeymapOutputType.MOUSE, "Mouse Middle", "mousemiddle"));
             allOutputs.Add(new KeymapOutput(KeymapOutputType.MOUSE, "Mouse Right", "mouseright"));
-            allOutputs.Add(new KeymapOutput(KeymapOutputType.MOUSE, "Mouse Wheel Uo", "mousewheelup"));
+            allOutputs.Add(new KeymapOutput(KeymapOutputType.MOUSE, "Mouse Wheel Up", "mousewheelup"));
             allOutputs.Add(new KeymapOutput(KeymapOutputType.MOUSE, "Mouse Wheel Down", "mousewheeldown"));
             allOutputs.Add(new KeymapOutput(KeymapOutputType.MOUSE, "Mouse Move Right", "mousex+", true, true, false, false));
             allOutputs.Add(new KeymapOutput(KeymapOutputType.MOUSE, "Mouse Move Up", "mousey+", true, true, false, false));

--- a/WiiTUIO/MainWindow.xaml.cs
+++ b/WiiTUIO/MainWindow.xaml.cs
@@ -682,11 +682,6 @@ namespace WiiTUIO
                 if (report.numberPaired > 0)
                 {
                     Settings.Default.pairedOnce = true;
-
-                    if (report.deviceNames.Contains(@"Nintendo RVL-CNT-01-TR"))
-                    {
-                        this.ShowMessage("At least one of your Wiimotes is not compatible with the Microsoft Bluetooth Stack, use only Wiimotes manufactured before November 2011 or try the instructions on touchmote.net/wiimotetr ",MessageType.Info);
-                    }
                 }
             }
             else

--- a/WiiTUIO/WiiTUIO.csproj
+++ b/WiiTUIO/WiiTUIO.csproj
@@ -501,7 +501,7 @@ copy "$(ProjectDir)VMultiDll_$(PlatformName).dll" "$(TargetDir)VMultiDll.dll" /Y
 xcopy "$(TargetDir)..\$(ConfigurationName)" "C:\Program Files\Touchmote" /H /Y
 cd "C:\Program Files\Touchmote"
 
-"C:\Program Files (x86)\Windows Kits\8.1\bin\$(PlatformName)\signtool.exe" sign /v /a /s ROOT /n Touchmote /t http://timestamp.verisign.com/scripts/timstamp.dll "C:\Program Files\Touchmote\Touchmote.exe"
+"C:\Program Files (x86)\Windows Kits\8.1\bin\$(PlatformName)\signtool.exe" sign /v /a /s ROOT /n Touchmote /t http://timestamp.digicert.com/scripts/timstamp.dll "C:\Program Files\Touchmote\Touchmote.exe"
 
 :END</PostBuildEvent>
   </PropertyGroup>


### PR DESCRIPTION
Remove TR non compatible message when syncing. Touchmote is compatible with TR wiimotes since many builds.