### PR TITLE
Added rotation, rumble, shake 

### DIFF
--- a/WiiTUIO/Input/WiiProvider/Keymap/WiiKeyMap.cs
+++ b/WiiTUIO/Input/WiiProvider/Keymap/WiiKeyMap.cs
@@ -33,6 +33,8 @@ namespace WiiTUIO.Provider
 
         private Dictionary<string, bool> PressedButtons = new Dictionary<string, bool>()
         {
+            {"Rotation+",false},
+            {"Rotation-",false},
             {"AccelX+",false},
             {"AccelX-",false},
             {"AccelY+",false},
@@ -137,13 +139,63 @@ namespace WiiTUIO.Provider
                         {
                             if (output.Cursor)
                             {
-                                if (cursorHandler.setPosition(output.Key,cursorPosition))
+                                if (cursorHandler.setPosition(output.Key, cursorPosition))
                                 {
                                     break; // we will break for the first accepting handler, for each output key
                                 }
                             }
                         }
                     }
+                }
+            }
+            if (this.config.TryGetValue("Rotation-", out outConfig))
+            {
+                if (!cursorPosition.OutOfReach)
+                {
+                    if (cursorPosition.Rotation < 0)
+                        updateStickHandlers(outConfig, -cursorPosition.Rotation);
+                }
+                else
+                {
+                    updateStickHandlers(outConfig, 0);
+                    PressedButtons["Rotation-"] = false;
+                    this.executeButtonUp("Rotation-");
+                }
+
+                if (-cursorPosition.Rotation > outConfig.Threshold && !PressedButtons["Rotation-"])
+                {
+                    PressedButtons["Rotation-"] = true;
+                    this.executeButtonDown("Rotation-");
+                }
+                else if (-cursorPosition.Rotation < outConfig.Threshold && PressedButtons["Rotation-"])
+                {
+                    PressedButtons["Rotation-"] = false;
+                    this.executeButtonUp("Rotation-");
+                }
+            }
+            if (this.config.TryGetValue("Rotation+", out outConfig))
+            {
+                if (!cursorPosition.OutOfReach)
+                {
+                    if (cursorPosition.Rotation > 0)
+                        updateStickHandlers(outConfig, cursorPosition.Rotation);
+                }
+                else
+                {
+                    updateStickHandlers(outConfig, 0);
+                    PressedButtons["Rotation+"] = false;
+                    this.executeButtonUp("Rotation+");
+                }
+
+                if (cursorPosition.Rotation > outConfig.Threshold && !PressedButtons["Rotation+"])
+                {
+                    PressedButtons["Rotation+"] = true;
+                    this.executeButtonDown("Rotation+");
+                }
+                else if (cursorPosition.Rotation < outConfig.Threshold && PressedButtons["Rotation+"])
+                {
+                    PressedButtons["Rotation+"] = false;
+                    this.executeButtonUp("Rotation+");
                 }
             }
         }

--- a/WiiTUIO/Input/WiiProvider/Keymap/WiiKeyMap.cs
+++ b/WiiTUIO/Input/WiiProvider/Keymap/WiiKeyMap.cs
@@ -614,20 +614,19 @@ namespace WiiTUIO.Provider
             {
                 var now = DateTime.Now;
 
-                double deltaX = Math.Abs(accelState.Values.X - lastAccelState.Values.X);
-                double deltaY = Math.Abs(accelState.Values.Y - lastAccelState.Values.Y);
-                double deltaZ = Math.Abs(accelState.Values.Z - lastAccelState.Values.Z);
+                float totalAccel = (float)Math.Sqrt(Math.Pow(accelState.Values.X, 2) + Math.Pow(accelState.Values.Y, 2) + Math.Pow(accelState.Values.Z, 2));
+                float delta = totalAccel - lastAccel;
+                smoothedAccel = smoothedAccel * 0.9f + delta;
+                Console.WriteLine(smoothedAccel);
 
-                double magnitude = Math.Sqrt(Math.Pow(deltaX, 2) + Math.Pow(deltaY, 2) + Math.Pow(deltaZ, 2));
-
-                if (PressedButtons["Shake"] == false)
+                if (!PressedButtons["Shake"])
                 {
-                    if (magnitude > ShakeThreshold && (deltaX > SuddenMovementThreshold || deltaY > SuddenMovementThreshold || deltaZ > SuddenMovementThreshold))
+                    if (Math.Abs(smoothedAccel) > Settings.Default.shake_threshold)
                     {
-                        if ((now - lastShakeTime).TotalMilliseconds < MaxTimeBetweenShakes)
+                        if ((now - lastShakeTime).TotalMilliseconds < Settings.Default.shake_maxTimeInBetween)
                         {
                             ShakeCounter++;
-                            if (ShakeCounter >= ShakeCount)
+                            if (ShakeCounter >= Settings.Default.shake_count)
                             {
                                 PressedButtons["Shake"] = true;
                                 this.executeButtonDown("Shake");
@@ -636,17 +635,17 @@ namespace WiiTUIO.Provider
                         }
                         else
                         {
-                            ShakeCounter = 1;
+                            ShakeCounter = 0;
                         }
                         lastShakeTime = now;
                     }
                 }
-                else if ((now - lastShakeTime).TotalMilliseconds > ShakePressedTime)
+                else if ((now - lastShakeTime).TotalMilliseconds > Settings.Default.shake_pressedTime)
                 {
                     PressedButtons["Shake"] = false;
                     this.executeButtonUp("Shake");
                 }
-                lastAccelState = accelState;
+                lastAccel = totalAccel;
             }
         }
 

--- a/WiiTUIO/Input/WiiProvider/Keymap/WiiKeyMap.cs
+++ b/WiiTUIO/Input/WiiProvider/Keymap/WiiKeyMap.cs
@@ -34,14 +34,10 @@ namespace WiiTUIO.Provider
         private double inputAngle = 0;
         private double prevAngle = 0;
 
-        private const double ShakeThreshold = 0.8; 
-        private const int ShakeCount = 2;
-        private const double SuddenMovementThreshold = 0.8;
-        private const int MaxTimeBetweenShakes = 1000;
-        private const int ShakePressedTime = 100;
         private int ShakeCounter = 0;
         private DateTime lastShakeTime;
-        private AccelState lastAccelState;
+        private float lastAccel;
+        private float smoothedAccel;
 
         private Dictionary<string, bool> PressedButtons = new Dictionary<string, bool>()
         {

--- a/WiiTUIO/Input/WiiProvider/Keymap/WiiKeyMap.cs
+++ b/WiiTUIO/Input/WiiProvider/Keymap/WiiKeyMap.cs
@@ -31,6 +31,9 @@ namespace WiiTUIO.Provider
 
         private long id;
 
+        private double inputAngle = 0;
+        private double prevAngle = 0;
+
         private Dictionary<string, bool> PressedButtons = new Dictionary<string, bool>()
         {
             {"Rotation+",false},
@@ -45,6 +48,8 @@ namespace WiiTUIO.Provider
             {"Nunchuk.StickDown",false},
             {"Nunchuk.StickLeft",false},
             {"Nunchuk.StickRight",false},
+            {"Nunchuk.Rotation+",false},
+            {"Nunchuk.Rotation-",false},
             {"Nunchuk.AccelX+",false},
             {"Nunchuk.AccelX-",false},
             {"Nunchuk.AccelY+",false},
@@ -430,6 +435,35 @@ namespace WiiTUIO.Provider
                     PressedButtons["Nunchuk.StickDown"] = false;
                     this.executeButtonUp("Nunchuk.StickDown");
                 }
+            }
+            
+            prevAngle = inputAngle;
+
+            if (this.config.TryGetValue("Nunchuk.Rotation+", out outConfig))
+            {
+                if (Math.Abs(nunchuk.Joystick.Y) * 2 > outConfig.Threshold || Math.Abs(nunchuk.Joystick.X) * 2 > outConfig.Threshold) //Only calculate if the stick exceeds the threshold value
+                    inputAngle = Math.Atan2(nunchuk.Joystick.Y, nunchuk.Joystick.X) / Math.PI;
+                else
+                    inputAngle = 0;
+            }
+            if (this.config.TryGetValue("Nunchuk.Rotation-", out outConfig))
+            {
+                if (Math.Abs(nunchuk.Joystick.Y) * 2 > outConfig.Threshold || Math.Abs(nunchuk.Joystick.X) * 2 > outConfig.Threshold)
+                    inputAngle = Math.Atan2(nunchuk.Joystick.Y, nunchuk.Joystick.X) / Math.PI;
+                else
+                    inputAngle = 0;
+            }
+
+            double angleDiff = (inputAngle - prevAngle);
+
+            if (angleDiff != 0) //If the angle changed
+            {
+                this.executeButtonDown(angleDiff > 0 ? "Nunchuk.Rotation-" : "Nunchuk.Rotation+");
+            }
+            else //No rotation
+            {
+                this.executeButtonUp("Nunchuk.Rotation+");
+                this.executeButtonUp("Nunchuk.Rotation-");
             }
 
             AccelState accelState = nunchuk.AccelState;

--- a/WiiTUIO/KeymapConfig/KeymapDatabase.cs
+++ b/WiiTUIO/KeymapConfig/KeymapDatabase.cs
@@ -38,8 +38,8 @@ namespace WiiTUIO
 
             allInputs = new List<KeymapInput>();
             allInputs.Add(new KeymapInput(KeymapInputSource.IR, "Pointer", "Pointer", false, false, true));
-            allInputs.Add(new KeymapInput(KeymapInputSource.IR, "Rotation+", "Rotation+", true, true, false));
-            allInputs.Add(new KeymapInput(KeymapInputSource.IR, "Rotation-", "Rotation-", true, true, false));
+            allInputs.Add(new KeymapInput(KeymapInputSource.IR, "Pointer Rotation-   ", "Rotation-", true, true, false));
+            allInputs.Add(new KeymapInput(KeymapInputSource.IR, "Pointer Rotation+   ", "Rotation+", true, true, false));
             allInputs.Add(new KeymapInput(KeymapInputSource.WIIMOTE, "A", "A"));
             allInputs.Add(new KeymapInput(KeymapInputSource.WIIMOTE, "B", "B"));
             allInputs.Add(new KeymapInput(KeymapInputSource.WIIMOTE, "Home", "Home"));
@@ -64,8 +64,8 @@ namespace WiiTUIO
             allInputs.Add(new KeymapInput(KeymapInputSource.NUNCHUK, "Stick Down", "Nunchuk.StickDown", true, true, false));
             allInputs.Add(new KeymapInput(KeymapInputSource.NUNCHUK, "Stick Left", "Nunchuk.StickLeft", true, true, false));
             allInputs.Add(new KeymapInput(KeymapInputSource.NUNCHUK, "Stick Right", "Nunchuk.StickRight", true, true, false));
-            allInputs.Add(new KeymapInput(KeymapInputSource.NUNCHUK, "Stick Rotation+", "Nunchuk.Rotation+"));
             allInputs.Add(new KeymapInput(KeymapInputSource.NUNCHUK, "Stick Rotation-", "Nunchuk.Rotation-"));
+            allInputs.Add(new KeymapInput(KeymapInputSource.NUNCHUK, "Stick Rotation+", "Nunchuk.Rotation+"));
             allInputs.Add(new KeymapInput(KeymapInputSource.NUNCHUK, "Tilt X-", "Nunchuk.AccelX-", true, true, false));
             allInputs.Add(new KeymapInput(KeymapInputSource.NUNCHUK, "Tilt X+", "Nunchuk.AccelX+", true, true, false));
             allInputs.Add(new KeymapInput(KeymapInputSource.NUNCHUK, "Tilt Y-", "Nunchuk.AccelY-", true, true, false));

--- a/WiiTUIO/KeymapConfig/KeymapDatabase.cs
+++ b/WiiTUIO/KeymapConfig/KeymapDatabase.cs
@@ -57,6 +57,7 @@ namespace WiiTUIO
             allInputs.Add(new KeymapInput(KeymapInputSource.WIIMOTE, "Tilt Y+", "AccelY+", true, true, false));
             allInputs.Add(new KeymapInput(KeymapInputSource.WIIMOTE, "Tilt Z-", "AccelZ-", true, true, false));
             allInputs.Add(new KeymapInput(KeymapInputSource.WIIMOTE, "Tilt Z+", "AccelZ+", true, true, false));
+            allInputs.Add(new KeymapInput(KeymapInputSource.WIIMOTE, "Shake", "Shake"));
 
             allInputs.Add(new KeymapInput(KeymapInputSource.NUNCHUK, "C", "Nunchuk.C"));
             allInputs.Add(new KeymapInput(KeymapInputSource.NUNCHUK, "Z", "Nunchuk.Z"));

--- a/WiiTUIO/KeymapConfig/KeymapDatabase.cs
+++ b/WiiTUIO/KeymapConfig/KeymapDatabase.cs
@@ -38,6 +38,8 @@ namespace WiiTUIO
 
             allInputs = new List<KeymapInput>();
             allInputs.Add(new KeymapInput(KeymapInputSource.IR, "Pointer", "Pointer", false, false, true));
+            allInputs.Add(new KeymapInput(KeymapInputSource.IR, "Rotation+", "Rotation+", true, true, false));
+            allInputs.Add(new KeymapInput(KeymapInputSource.IR, "Rotation-", "Rotation-", true, true, false));
             allInputs.Add(new KeymapInput(KeymapInputSource.WIIMOTE, "A", "A"));
             allInputs.Add(new KeymapInput(KeymapInputSource.WIIMOTE, "B", "B"));
             allInputs.Add(new KeymapInput(KeymapInputSource.WIIMOTE, "Home", "Home"));

--- a/WiiTUIO/KeymapConfig/KeymapDatabase.cs
+++ b/WiiTUIO/KeymapConfig/KeymapDatabase.cs
@@ -281,6 +281,9 @@ namespace WiiTUIO
             allOutputs.Add(new KeymapOutput(KeymapOutputType.XINPUT, "Right Stick Down", "360.stickrdown", true, true, false, false));
             allOutputs.Add(new KeymapOutput(KeymapOutputType.XINPUT, "Right Stick Left", "360.stickrleft", true, true, false, false));
             allOutputs.Add(new KeymapOutput(KeymapOutputType.XINPUT, "Right Stick Right", "360.stickrright", true, true, false, false));
+            allOutputs.Add(new KeymapOutput(KeymapOutputType.XINPUT, "Rumble On Hold", "360.rumble"));
+            allOutputs.Add(new KeymapOutput(KeymapOutputType.XINPUT, "Rumble Once", "360.rumble1"));
+            allOutputs.Add(new KeymapOutput(KeymapOutputType.XINPUT, "Rumble M. Gun", "360.rumble2"));
             allOutputs.Add(new KeymapOutput(KeymapOutputType.XINPUT, "Left Trigger", "360.triggerl", true, true, false, false));
             allOutputs.Add(new KeymapOutput(KeymapOutputType.XINPUT, "Right Trigger", "360.triggerr", true, true, false, false));
             allOutputs.Add(new KeymapOutput(KeymapOutputType.XINPUT, "Left Bumper", "360.bumperl"));

--- a/WiiTUIO/KeymapConfig/KeymapDatabase.cs
+++ b/WiiTUIO/KeymapConfig/KeymapDatabase.cs
@@ -64,6 +64,8 @@ namespace WiiTUIO
             allInputs.Add(new KeymapInput(KeymapInputSource.NUNCHUK, "Stick Down", "Nunchuk.StickDown", true, true, false));
             allInputs.Add(new KeymapInput(KeymapInputSource.NUNCHUK, "Stick Left", "Nunchuk.StickLeft", true, true, false));
             allInputs.Add(new KeymapInput(KeymapInputSource.NUNCHUK, "Stick Right", "Nunchuk.StickRight", true, true, false));
+            allInputs.Add(new KeymapInput(KeymapInputSource.NUNCHUK, "Stick Rotation+", "Nunchuk.Rotation+"));
+            allInputs.Add(new KeymapInput(KeymapInputSource.NUNCHUK, "Stick Rotation-", "Nunchuk.Rotation-"));
             allInputs.Add(new KeymapInput(KeymapInputSource.NUNCHUK, "Tilt X-", "Nunchuk.AccelX-", true, true, false));
             allInputs.Add(new KeymapInput(KeymapInputSource.NUNCHUK, "Tilt X+", "Nunchuk.AccelX+", true, true, false));
             allInputs.Add(new KeymapInput(KeymapInputSource.NUNCHUK, "Tilt Y-", "Nunchuk.AccelY-", true, true, false));

--- a/WiiTUIO/Properties/Settings.cs
+++ b/WiiTUIO/Properties/Settings.cs
@@ -597,6 +597,50 @@ namespace WiiTUIO.Properties
             }
         }
 
+        private double _shake_threshold = 1.5;
+        public double shake_threshold
+        {
+            get { return _shake_threshold; }
+            set
+            {
+                _shake_threshold = value;
+                OnPropertyChanged("shake_threshold");
+            }
+        }
+
+        private int _shake_count = 2;
+        public int shake_count
+        {
+            get { return _shake_count; }
+            set
+            {
+                _shake_count = value;
+                OnPropertyChanged("shake_count");
+            }
+        }
+
+        private int _shake_maxTimeInBetween = 500;
+        public int shake_maxTimeInBetween
+        {
+            get { return _shake_maxTimeInBetween; }
+            set
+            {
+                _shake_maxTimeInBetween = value;
+                OnPropertyChanged("shake_maxTimeInBetween");
+            }
+        }
+
+        private int _shake_pressedTime = 200;
+        public int shake_pressedTime
+        {
+            get { return _shake_pressedTime; }
+            set
+            {
+                _shake_pressedTime = value;
+                OnPropertyChanged("shake_pressedTime");
+            }
+        }
+
         private int _touch_touchTapThreshold = 40;
         public int touch_touchTapThreshold
         {


### PR DESCRIPTION
"pointer_considerRotation": should be set to true when want to use this feature.

Maybe some rotation routine should be reviewed to avoid axis inverted problem when pointing too much outside the screen or making strange moves with the wiimote (this is a tmote problem, not related to this commit)

When turning on "pointer_considerRotation" cursor has more problems reaching the corners of the screen. Probably is not using the new smoothing code and some new values.